### PR TITLE
test: add pytest CLI integration tests as refactor regression baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ transactions/*.csv
 transactions/*.pdf
 ifu/
 fx_cache.json
+tests/output/

--- a/src/wise_csv_ifu.py
+++ b/src/wise_csv_ifu.py
@@ -370,6 +370,8 @@ def main():
     parser.add_argument('-s', action='store_true', dest='penalty_s')
     parser.add_argument('-f', action='store_true', dest='penalty_f')
     parser.add_argument('-ff', action='store_true', dest='penalty_ff')
+    parser.add_argument('--out', default='ifu',
+                        help="Dossier racine pour les fichiers de sortie (défaut: 'ifu')")
     args = parser.parse_args()
 
     if args.penalty_ff:
@@ -384,7 +386,7 @@ def main():
 
     target_year = args.year
     folder = Path(args.folder)
-    out_dir = Path('ifu') / str(target_year) / 'wise'
+    out_dir = Path(args.out) / str(target_year) / 'wise'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if not folder.is_dir():

--- a/src/yuh_csv_ifu.py
+++ b/src/yuh_csv_ifu.py
@@ -399,6 +399,8 @@ def main():
                         help="Alias : -cldp --penalty-scenario formal (après mise en demeure, majoration 40 %%)")
     parser.add_argument('-ff', action='store_true', dest='penalty_ff',
                         help="Alias : -cldp --penalty-scenario fraud (manœuvres frauduleuses, majoration 80 %%)")
+    parser.add_argument('--out', default='ifu',
+                        help="Dossier racine pour les fichiers de sortie (défaut: 'ifu')")
     args = parser.parse_args()
 
     # Résoudre les alias de scénario de pénalité
@@ -414,7 +416,7 @@ def main():
 
     target_year = args.year
     folder = Path(args.folder)
-    out_dir = Path('ifu') / str(target_year) / 'yuh'
+    out_dir = Path(args.out) / str(target_year) / 'yuh'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if not folder.is_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+TRANSACTIONS = REPO_ROOT / "transactions"
+GOLDEN_ROOT = REPO_ROOT / "ifu"
+OUTPUT_ROOT = REPO_ROOT / "tests" / "output"
+FX_CACHE = REPO_ROOT / "fx_cache.json"
+YEARS = [2023, 2024, 2025]
+
+_DATE_PATTERN = re.compile(r'Généré le \d{4}-\d{2}-\d{2}')
+
+
+def normalize(content: str) -> str:
+    """Normalize line endings, trailing whitespace, and volatile date stamps."""
+    lines = content.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+    stripped = [_DATE_PATTERN.sub('Généré le DATE', line.rstrip()) for line in lines]
+    return '\n'.join(stripped).strip()
+
+
+def _inputs_available() -> bool:
+    return TRANSACTIONS.is_dir() and FX_CACHE.exists()
+
+
+def _has_yuh_csv(year: int) -> bool:
+    upper = list(TRANSACTIONS.glob(f"yuh_ACTIVITIES_REPORT-{year}.CSV"))
+    lower = list(TRANSACTIONS.glob(f"yuh_ACTIVITIES_REPORT-{year}.csv"))
+    return bool(upper or lower)
+
+
+def _has_wise_csv(year: int) -> bool:
+    return bool(list(TRANSACTIONS.glob(f"wise_assets_statement_*{year}*.csv")))
+
+
+def _run(script: str, arguments: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "src" / script)] + arguments,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding='utf-8',
+    )
+
+
+def _generate_year(year: int) -> None:
+    shared = ["--folder", str(TRANSACTIONS), "--cache", "fx_cache.json", "--out", str(OUTPUT_ROOT)]
+    if _has_yuh_csv(year):
+        _run("yuh_csv_ifu.py", [str(year)] + shared)
+    if _has_wise_csv(year):
+        _run("wise_csv_ifu.py", [str(year)] + shared)
+    _run("unified_readme.py", [str(year), "--ifu-root", str(OUTPUT_ROOT)])
+
+
+@pytest.fixture(scope="session", autouse=True)
+def generate_outputs() -> None:
+    if not _inputs_available():
+        return
+    OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    for year in YEARS:
+        _generate_year(year)

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from conftest import GOLDEN_ROOT, OUTPUT_ROOT, TRANSACTIONS, FX_CACHE, YEARS, normalize
+
+
+def _inputs_available() -> bool:
+    return TRANSACTIONS.is_dir() and FX_CACHE.exists()
+
+
+def _golden_csvs(year: int, broker: str) -> list[Path]:
+    golden_dir = GOLDEN_ROOT / str(year) / broker
+    if not golden_dir.is_dir():
+        return []
+    return sorted(f for f in golden_dir.iterdir() if f.suffix == '.csv')
+
+
+def _assert_csvs_match(year: int, broker: str) -> None:
+    for golden_file in _golden_csvs(year, broker):
+        output_file = OUTPUT_ROOT / str(year) / broker / golden_file.name
+        assert output_file.exists(), f"Missing output: {output_file.relative_to(OUTPUT_ROOT)}"
+        expected = normalize(golden_file.read_text(encoding="utf-8"))
+        actual = normalize(output_file.read_text(encoding="utf-8"))
+        assert actual == expected, f"Content mismatch: {broker}/{year}/{golden_file.name}"
+
+
+@pytest.mark.parametrize("year", YEARS)
+def test_yuh_csvs_match_golden(year: int) -> None:
+    if not _golden_csvs(year, "yuh"):
+        pytest.skip(f"No golden yuh CSVs for {year}")
+    if not _inputs_available():
+        pytest.skip("transactions/ or fx_cache.json not available")
+    _assert_csvs_match(year, "yuh")
+
+
+@pytest.mark.parametrize("year", YEARS)
+def test_wise_csvs_match_golden(year: int) -> None:
+    if not _golden_csvs(year, "wise"):
+        pytest.skip(f"No golden wise CSVs for {year}")
+    if not _inputs_available():
+        pytest.skip("transactions/ or fx_cache.json not available")
+    _assert_csvs_match(year, "wise")


### PR DESCRIPTION
## Summary

- Added `--out` flag to `yuh_csv_ifu.py` and `wise_csv_ifu.py` so the output root is configurable (default remains `ifu/`, no breaking change)
- Added `tests/conftest.py`: session-scoped fixture that runs all three scripts into `tests/output/` using the local `transactions/` CSVs and `fx_cache.json`
- Added `tests/test_cli_integration.py`: 6 parametrised tests (2023/2024/2025 × yuh/wise) that diff every generated CSV against its golden counterpart in `ifu/<year>/`; tests skip gracefully when local data files are absent (gitignored)
- Added `tests/output/` to `.gitignore`

Closes #5

## Test plan

- [x] Run `python -m pytest tests/ -v` locally — should show 5 passed, 1 skipped (2023 wise, no input CSV)
- [ ] Confirm tests still pass after any subsequent refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)