### PR TITLE
refactor: decouple FXCache into standalone src/fx_cache.py module

### DIFF
--- a/src/fx_cache.py
+++ b/src/fx_cache.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+fx_cache.py — Cache persistant des taux de change BCE via api.frankfurter.dev.
+
+Instancier FXCache(cache_path) pour charger/sauvegarder depuis un fichier JSON.
+Ou FXCache(preloaded={...}) pour injecter un dictionnaire en mémoire (tests, etc.).
+"""
+import json
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+try:
+    import requests
+except ImportError:
+    import sys
+    print("Manque une dépendance. Installez avec : pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+
+def _read_json_file(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def _init_cache(cache_path: Optional[Path], preloaded: Optional[dict]) -> dict:
+    if preloaded is not None:
+        return dict(preloaded)
+    if cache_path is not None and cache_path.exists():
+        return _read_json_file(cache_path)
+    return {}
+
+
+class FXCache:
+    """Cache persistant des taux {currency}→EUR BCE via api.frankfurter.dev."""
+
+    API = "https://api.frankfurter.dev/v1/{date}?from={currency}&to=EUR"
+
+    def __init__(self, cache_path: Optional[Path] = None, preloaded: Optional[dict] = None):
+        self.cache_path = cache_path
+        self.cache: dict = _init_cache(cache_path, preloaded)
+
+    def _save(self) -> None:
+        if self.cache_path is None:
+            return
+        self.cache_path.write_text(json.dumps(self.cache, indent=2, sort_keys=True))
+
+    def _cached_entry(self, key: str) -> Optional[tuple]:
+        if key not in self.cache:
+            return None
+        entry = self.cache[key]
+        return entry['rate'], entry['bce_date']
+
+    def _parse_payload(self, payload: dict, key: str, fallback_date: str) -> tuple:
+        if 'rates' not in payload or 'EUR' not in payload['rates']:
+            raise RuntimeError(f"Réponse inattendue pour {key}: {payload}")
+        rate = float(payload['rates']['EUR'])
+        return rate, payload.get('date', fallback_date)
+
+    def _record_rate(self, key: str, rate: float, bce_date: str) -> None:
+        self.cache[key] = {'rate': rate, 'bce_date': bce_date}
+        self._save()
+
+    def _fetch_and_store(self, d: date, currency: str, key: str) -> tuple:
+        response = requests.get(self.API.format(date=d.isoformat(), currency=currency), timeout=15)
+        response.raise_for_status()
+        rate, bce_date = self._parse_payload(response.json(), key, d.isoformat())
+        self._record_rate(key, rate, bce_date)
+        return rate, bce_date
+
+    def _get_non_eur(self, d: date, currency: str) -> tuple:
+        key = f"{d.isoformat()}_{currency}"
+        cached = self._cached_entry(key)
+        if cached is not None:
+            return cached
+        return self._fetch_and_store(d, currency, key)
+
+    def get(self, d: date, currency: str = 'CHF') -> tuple:
+        """Retourne (taux→EUR, date_BCE_réelle). Retourne (1.0, date) pour EUR."""
+        if currency == 'EUR':
+            return 1.0, d.isoformat()
+        return self._get_non_eur(d, currency)

--- a/src/wise_csv_ifu.py
+++ b/src/wise_csv_ifu.py
@@ -43,7 +43,6 @@ Dépendances :
 """
 import argparse
 import csv
-import json
 import math
 import sys
 from dataclasses import dataclass, asdict
@@ -56,11 +55,7 @@ if hasattr(sys.stdout, 'reconfigure'):
 if hasattr(sys.stderr, 'reconfigure'):
     sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
-try:
-    import requests
-except ImportError:
-    print("Dépendance manquante : pip install requests", file=sys.stderr)
-    sys.exit(1)
+from fx_cache import FXCache
 
 
 # ---------------------------------------------------------------------------
@@ -71,47 +66,6 @@ WISE_FUNDS: dict[str, str] = {
     'IE00B41N0724': 'EUR Interest fund',  # BlackRock ICS EUR Liquidity Fund (Irlande)
     'LU0852473015': 'Stocks fund',        # iShares World Equity Index Fund / MSCI World (Luxembourg)
 }
-
-
-# ---------------------------------------------------------------------------
-# Cache BCE multi-devises
-# ---------------------------------------------------------------------------
-class FXCache:
-    """Cache persistant des taux {currency}→EUR BCE via api.frankfurter.dev."""
-
-    API = "https://api.frankfurter.dev/v1/{date}?from={currency}&to=EUR"
-
-    def __init__(self, cache_path: Path):
-        self.cache_path = cache_path
-        self.cache: dict = {}
-        if cache_path.exists():
-            try:
-                self.cache = json.loads(cache_path.read_text())
-            except Exception:
-                self.cache = {}
-
-    def _save(self):
-        self.cache_path.write_text(json.dumps(self.cache, indent=2, sort_keys=True))
-
-    def get(self, d: date, currency: str = 'EUR') -> tuple[float, str]:
-        """Retourne (taux→EUR, date_BCE_réelle). Retourne (1.0, isodate) pour EUR."""
-        if currency == 'EUR':
-            return 1.0, d.isoformat()
-        key = f"{d.isoformat()}_{currency}"
-        if key in self.cache:
-            e = self.cache[key]
-            return e['rate'], e['bce_date']
-        url = self.API.format(date=d.isoformat(), currency=currency)
-        r = requests.get(url, timeout=15)
-        r.raise_for_status()
-        payload = r.json()
-        if 'rates' not in payload or 'EUR' not in payload['rates']:
-            raise RuntimeError(f"Réponse inattendue pour {key}: {payload}")
-        rate = float(payload['rates']['EUR'])
-        bce_date = payload.get('date', d.isoformat())
-        self.cache[key] = {'rate': rate, 'bce_date': bce_date}
-        self._save()
-        return rate, bce_date
 
 
 # ---------------------------------------------------------------------------

--- a/src/yuh_csv_ifu.py
+++ b/src/yuh_csv_ifu.py
@@ -31,7 +31,6 @@ Hypothèses :
 """
 import argparse
 import csv
-import json
 import math
 import re
 import sys
@@ -46,12 +45,7 @@ if hasattr(sys.stdout, 'reconfigure'):
 if hasattr(sys.stderr, 'reconfigure'):
     sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
-try:
-    import requests
-except ImportError:
-    print("Manque une dépendance. Installez avec : pip install requests", file=sys.stderr)
-    sys.exit(1)
-
+from fx_cache import FXCache
 from constants import (
     INVEST_ORDER_EXECUTED,
     INVEST_RECURRING_ORDER_EXECUTED,
@@ -119,48 +113,6 @@ class Transaction:
     fx_rate_date_used: Optional[str] = None
     total_eur: Optional[float] = None
     price_eur: Optional[float] = None
-
-
-# ---------------------------------------------------------------------------
-# Cache des taux de change BCE (multi-devises)
-# ---------------------------------------------------------------------------
-
-class FXCache:
-    """Cache persistant des taux {currency}→EUR de la BCE via api.frankfurter.dev."""
-
-    API = "https://api.frankfurter.dev/v1/{date}?from={currency}&to=EUR"
-
-    def __init__(self, cache_path: Path):
-        self.cache_path = cache_path
-        self.cache: dict[str, dict] = {}
-        if cache_path.exists():
-            try:
-                self.cache = json.loads(cache_path.read_text())
-            except Exception:
-                self.cache = {}
-
-    def _save(self):
-        self.cache_path.write_text(json.dumps(self.cache, indent=2, sort_keys=True))
-
-    def get(self, d: date, currency: str = 'CHF') -> tuple[float, str]:
-        """Retourne (taux→EUR, date_BCE_réelle). Retourne (1.0, date) pour EUR."""
-        if currency == 'EUR':
-            return 1.0, d.isoformat()
-        key = f"{d.isoformat()}_{currency}"
-        if key in self.cache:
-            entry = self.cache[key]
-            return entry['rate'], entry['bce_date']
-        url = self.API.format(date=d.isoformat(), currency=currency)
-        r = requests.get(url, timeout=15)
-        r.raise_for_status()
-        payload = r.json()
-        if 'rates' not in payload or 'EUR' not in payload['rates']:
-            raise RuntimeError(f"Réponse inattendue pour {key}: {payload}")
-        rate = float(payload['rates']['EUR'])
-        bce_date = payload.get('date', d.isoformat())
-        self.cache[key] = {'rate': rate, 'bce_date': bce_date}
-        self._save()
-        return rate, bce_date
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fx_cache.py
+++ b/tests/test_fx_cache.py
@@ -1,0 +1,27 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from fx_cache import FXCache
+
+
+def test_fx_cache_loads_from_existing_file(tmp_path: Path) -> None:
+    cache_file = tmp_path / "fx_cache.json"
+    data = {"2024-01-15_CHF": {"rate": 1.05, "bce_date": "2024-01-15"}}
+    cache_file.write_text(json.dumps(data))
+
+    fx = FXCache(cache_path=cache_file)
+
+    assert fx.cache == data
+
+
+def test_fx_cache_starts_empty_when_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "no_such_file.json"
+
+    fx = FXCache(cache_path=missing)
+
+    assert fx.cache == {}


### PR DESCRIPTION
## Summary

- Extracted the duplicated `FXCache` class from both `yuh_csv_ifu.py` and `wise_csv_ifu.py` into a new `src/fx_cache.py` module
- Added `preloaded: Optional[dict]` parameter so callers can inject an in-memory cache dict without requiring a file (enables clean unit testing)
- Kept default CLI behaviour unchanged: `FXCache(Path(args.cache))` still loads from and saves to the JSON file on disk
- Removed duplicate `import json` and `try: import requests` blocks from both scripts
- Added two unit tests in `tests/test_fx_cache.py` covering file-present and file-absent init paths

Closes #6

## Test plan

- [x] `test_fx_cache_loads_from_existing_file` — FXCache reads a pre-written JSON file correctly
- [x] `test_fx_cache_starts_empty_when_file_missing` — FXCache starts with an empty cache when the file doesn't exist
- [x] All existing golden CSV tests pass (`test_yuh_csvs_match_golden`, `test_wise_csvs_match_golden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)