### PR TITLE
feat: add standalone csv_to_excel.py to export IFU CSVs as Excel workbooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | `src/fees_by_activity.py` | Debug utility: groups Yuh `FEES/COMMISSION` by `ACTIVITY_TYPE` |
 | `src/constants.py` | `ACTIVITY_TYPE` string constants for Yuh CSV rows |
 | `src/ticker_isin.py` | `TICKER_ISIN` dict (Yuh ticker → ISIN + name). Update when new securities appear. |
+| `src/csv_to_excel.py` | Standalone script: reads broker CSV outputs and writes `<broker>_<year>_ifu.xlsx` into `<ifu-root>/<year>/excel/`. Run after the broker scripts. |
 
 Shell wrappers in `scripts/` call the Python scripts from the repo root.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Generates French tax declaration data (IFU equivalent) for French-resident cross-border workers (frontaliers) holding investment accounts at **Yuh/Swissquote** and/or **Wise Assets**.
 
-Implements the **PMP method** (art. 150-0 D CGI) with ECB CHF→EUR exchange rates. 
+Implements the **PMP method** (art. 150-0 D CGI) with ECB CHF→EUR exchange rates.
 
-Produces per year and  broker:
+Produces per year and broker:
+
 - CSVs with detailed data, if the authorities ask for them
-- a summary Markdown file. 
+- a summary Markdown file.
 
 A unified Markdown summary per year provide the figures to fill in forms 2074, 2086, and 2042.
 
@@ -14,10 +15,10 @@ A unified Markdown summary per year provide the figures to fill in forms 2074, 2
 
 ## Supported brokers
 
-| Broker | Input files | Output folder |
-|--------|------------|---------------|
-| Yuh / Swissquote | `ACTIVITIES_REPORT-*.CSV` | `ifu-new/<year>/yuh/` |
-| Wise Assets | `wise_assets_statement_*.csv` | `ifu-new/<year>/wise/` |
+| Broker           | Input files                   | Output folder          |
+| ---------------- | ----------------------------- | ---------------------- |
+| Yuh / Swissquote | `ACTIVITIES_REPORT-*.CSV`     | `ifu-new/<year>/yuh/`  |
+| Wise Assets      | `wise_assets_statement_*.csv` | `ifu-new/<year>/wise/` |
 
 ---
 
@@ -26,6 +27,11 @@ A unified Markdown summary per year provide the figures to fill in forms 2074, 2
 ```bash
 pip install -r requirements.txt
 ```
+
+Dependencies:
+
+- `requests` for ECB exchange rates
+- `openpyxl` for Excel export
 
 ---
 
@@ -57,14 +63,14 @@ python src/yuh_csv_ifu.py 2024 -ff   # fraud (80 %)
 
 **Output files** in `ifu-new/<year>/yuh/`:
 
-| File | Content |
-|------|---------|
-| `<year>_transactions.csv` | All operations with CHF/USD→EUR conversion |
-| `<year>_gains_2074.csv` | Capital gains/losses → form 2074 (securities); includes `Taux PFU` column |
-| `<year>_gains_2086.csv` | Crypto-ETP gains → form 2086 (informational); includes `Taux PFU` column |
-| `<year>_dividendes.csv` | Dividends and distributions |
-| `<year>_summary.csv` | Positions and PMP at 31/12 |
-| `<year>_fx_log.csv` | ECB rates used |
+| File                      | Content                                                                   |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `<year>_transactions.csv` | All operations with CHF/USD→EUR conversion                                |
+| `<year>_gains_2074.csv`   | Capital gains/losses → form 2074 (securities); includes `Taux PFU` column |
+| `<year>_gains_2086.csv`   | Crypto-ETP gains → form 2086 (informational); includes `Taux PFU` column  |
+| `<year>_dividendes.csv`   | Dividends and distributions                                               |
+| `<year>_summary.csv`      | Positions and PMP at 31/12                                                |
+| `<year>_fx_log.csv`       | ECB rates used                                                            |
 
 ---
 
@@ -84,14 +90,33 @@ Same `--de-ruyter-periods` and penalty flags (`-s`, `-f`, `-ff`) apply.
 
 **Output files** in `ifu-new/<year>/wise/`:
 
-| File | Content |
-|------|---------|
-| `<year>_transactions.csv` | All operations with EUR conversion |
-| `<year>_gains_2074.csv` | Capital gains/losses → form 2074; includes `Taux PFU` column |
-| `<year>_dividendes.csv` | Dividends (empty for accumulating funds) |
-| `<year>_fees.csv` | Monthly management fees (not deductible under PFU) |
-| `<year>_summary.csv` | Positions and PMP at 31/12 |
-| `<year>_fx_log.csv` | ECB rates used |
+| File                      | Content                                                      |
+| ------------------------- | ------------------------------------------------------------ |
+| `<year>_transactions.csv` | All operations with EUR conversion                           |
+| `<year>_gains_2074.csv`   | Capital gains/losses → form 2074; includes `Taux PFU` column |
+| `<year>_dividendes.csv`   | Dividends (empty for accumulating funds)                     |
+| `<year>_fees.csv`         | Monthly management fees (not deductible under PFU)           |
+| `<year>_summary.csv`      | Positions and PMP at 31/12                                   |
+| `<year>_fx_log.csv`       | ECB rates used                                               |
+
+---
+
+## Usage — Excel export
+
+After running either (or both) broker scripts, convert the CSVs to Excel workbooks:
+
+```bash
+python src/csv_to_excel.py 2024 [--ifu-root ifu-new]
+```
+
+**Output files** in `ifu-new/<year>/excel/`:
+
+| File                   | Sheets                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| `yuh_<year>_ifu.xlsx`  | One sheet per CSV (dividendes, fx_log, gains_2074, gains_2086, summary, transactions) |
+| `wise_<year>_ifu.xlsx` | One sheet per CSV (dividendes, fees, fx_log, gains_2074, summary, transactions)       |
+
+Only workbooks for broker subdirectories that already exist are created — no error if one broker is missing.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+openpyxl

--- a/src/csv_to_excel.py
+++ b/src/csv_to_excel.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+csv_to_excel.py — Converts IFU CSV outputs into per-broker Excel workbooks.
+
+Usage:
+    python src/csv_to_excel.py <year> [--ifu-root <dir>]
+
+For each broker subfolder (yuh, wise) found under <ifu-root>/<year>/,
+produces one Excel workbook in <ifu-root>/<year>/excel/ with one sheet
+per CSV file, named <broker>_<year>_ifu.xlsx.
+
+Run after yuh_csv_ifu.py and/or wise_csv_ifu.py have generated their CSVs.
+"""
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import openpyxl
+
+BROKERS = ('yuh', 'wise')
+
+
+def _sheet_name(csv_path: Path) -> str:
+    stem = csv_path.stem
+    parts = stem.split('_', 1)
+    if len(parts) == 2 and parts[0].isdigit():
+        return parts[1][:31]
+    return stem[:31]
+
+
+def _load_csv_rows(csv_path: Path) -> list[list[str]]:
+    with csv_path.open(encoding='utf-8', newline='') as file:
+        return list(csv.reader(file))
+
+
+def _write_sheet(workbook: openpyxl.Workbook, csv_path: Path) -> None:
+    sheet = workbook.create_sheet(title=_sheet_name(csv_path))
+    for row in _load_csv_rows(csv_path):
+        sheet.append(row)
+
+
+def _build_workbook(broker_dir: Path) -> openpyxl.Workbook:
+    workbook = openpyxl.Workbook()
+    workbook.remove(workbook.active)
+    for csv_path in sorted(broker_dir.glob('*.csv')):
+        _write_sheet(workbook, csv_path)
+    return workbook
+
+
+def _convert_broker(broker: str, year: int, year_dir: Path, excel_dir: Path) -> bool:
+    broker_dir = year_dir / broker
+    if not broker_dir.is_dir():
+        return False
+    csv_files = sorted(broker_dir.glob('*.csv'))
+    if not csv_files:
+        return False
+    excel_path = excel_dir / f'{broker}_{year}_ifu.xlsx'
+    _build_workbook(broker_dir).save(excel_path)
+    print(f"📊 {broker:5s} → {excel_path}  ({len(csv_files)} sheets)")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert IFU CSV outputs to Excel workbooks (one per broker)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('year', type=int, help='Fiscal year (e.g. 2024)')
+    parser.add_argument('--ifu-root', default='ifu-new',
+                        help="Root output directory (default: 'ifu-new')")
+    args = parser.parse_args()
+
+    year_dir = Path(args.ifu_root) / str(args.year)
+    if not year_dir.is_dir():
+        print(f"Directory not found: {year_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    excel_dir = year_dir / 'excel'
+    excel_dir.mkdir(exist_ok=True)
+
+    converted = [b for b in BROKERS if _convert_broker(b, args.year, year_dir, excel_dir)]
+    if not converted:
+        print(f"No broker CSV directories found under {year_dir}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/2026-05-05_convert-csv-to-excel.md
+++ b/tasks/2026-05-05_convert-csv-to-excel.md
@@ -1,0 +1,34 @@
+# Task: Convert IFU CSVs to Excel workbooks
+
+**Issue:** #20  
+**Branch:** `feat/convert-csv-to-excel`
+
+## Context
+
+After running `yuh_csv_ifu.py` or `wise_csv_ifu.py`, the output directory contains several CSV files per broker. Users need a single Excel workbook per broker for easier reading and sharing, without changing the CSV generation scripts themselves.
+
+## Feature description
+
+New standalone script `src/csv_to_excel.py`:
+
+- Reads CSV files from `<ifu-root>/<year>/yuh/` and/or `<ifu-root>/<year>/wise/`
+- Produces one `.xlsx` workbook per broker in `<ifu-root>/<year>/excel/`
+- Each CSV file becomes one sheet (sheet name = filename stem minus the year prefix)
+- Workbook naming: `<broker>_<year>_ifu.xlsx` (e.g. `yuh_2024_ifu.xlsx`)
+- Silently skips brokers whose subfolder does not exist
+
+## Usage
+
+```bash
+python src/csv_to_excel.py 2024
+python src/csv_to_excel.py 2024 --ifu-root ifu
+```
+
+## Verification steps
+
+- [x] Run `yuh_csv_ifu.py` for a given year to produce CSVs
+- [x] Run `python src/csv_to_excel.py <year>` and confirm `ifu-new/<year>/excel/yuh_<year>_ifu.xlsx` is created
+- [x] Open the workbook and verify one sheet per CSV, sheet names match CSV names (without year prefix)
+- [x] Run for a year that has both yuh and wise CSVs — confirm two workbooks are produced
+- [x] Run for a year with only one broker — confirm only one workbook is created, no error for the missing broker
+- [x] Verify accented characters (é, à, ô) in French column headers render correctly in Excel

--- a/tests/test_csv_to_excel.py
+++ b/tests/test_csv_to_excel.py
@@ -1,0 +1,191 @@
+import csv
+import sys
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from csv_to_excel import _build_workbook, _convert_broker, _sheet_name
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> None:
+    with path.open('w', newline='', encoding='utf-8') as f:
+        csv.writer(f).writerows(rows)
+
+
+def _sheet_rows(sheet) -> list[list]:
+    return [list(row) for row in sheet.iter_rows(values_only=True)]
+
+
+class TestCsvToExcel:
+    # ------------------------------------------------------------------
+    # _sheet_name
+    # ------------------------------------------------------------------
+
+    def test_year_prefix_stripped_from_sheet_name(self) -> None:
+        assert _sheet_name(Path('2024_transactions.csv')) == 'transactions'
+
+    def test_year_prefix_stripped_leaving_compound_name(self) -> None:
+        assert _sheet_name(Path('2024_gains_2074.csv')) == 'gains_2074'
+
+    def test_sheet_name_kept_when_no_year_prefix(self) -> None:
+        assert _sheet_name(Path('summary.csv')) == 'summary'
+
+    def test_sheet_name_truncated_to_31_chars(self) -> None:
+        long_name = Path(f'2024_{"x" * 40}.csv')
+        assert len(_sheet_name(long_name)) <= 31
+
+    # ------------------------------------------------------------------
+    # _build_workbook — sheet structure
+    # ------------------------------------------------------------------
+
+    def test_single_csv_produces_one_sheet(self, tmp_path: Path) -> None:
+        _write_csv(tmp_path / '2024_transactions.csv', [['Date', 'ISIN']])
+
+        workbook = _build_workbook(tmp_path)
+
+        assert workbook.sheetnames == ['transactions']
+
+    def test_multiple_csvs_produce_multiple_sheets(self, tmp_path: Path) -> None:
+        _write_csv(tmp_path / '2024_dividendes.csv', [['Date', 'Montant']])
+        _write_csv(tmp_path / '2024_transactions.csv', [['Date', 'ISIN']])
+
+        workbook = _build_workbook(tmp_path)
+
+        assert set(workbook.sheetnames) == {'dividendes', 'transactions'}
+
+    def test_sheets_ordered_alphabetically_by_csv_filename(self, tmp_path: Path) -> None:
+        _write_csv(tmp_path / '2024_transactions.csv', [['H']])
+        _write_csv(tmp_path / '2024_dividendes.csv', [['H']])
+        _write_csv(tmp_path / '2024_summary.csv', [['H']])
+
+        workbook = _build_workbook(tmp_path)
+
+        assert workbook.sheetnames == ['dividendes', 'summary', 'transactions']
+
+    def test_empty_directory_produces_workbook_with_no_sheets(self, tmp_path: Path) -> None:
+        workbook = _build_workbook(tmp_path)
+
+        assert workbook.sheetnames == []
+
+    # ------------------------------------------------------------------
+    # _build_workbook — content fidelity
+    # ------------------------------------------------------------------
+
+    def test_sheet_content_matches_csv_rows_exactly(self, tmp_path: Path) -> None:
+        rows = [['Date', 'ISIN', 'Montant EUR'], ['2024-01-15', 'IE00B41N0724', '100.00']]
+        _write_csv(tmp_path / '2024_transactions.csv', rows)
+
+        sheet = _build_workbook(tmp_path)['transactions']
+
+        assert _sheet_rows(sheet) == rows
+
+    def test_each_sheet_matches_its_own_csv(self, tmp_path: Path) -> None:
+        div_rows = [['Date', 'Montant'], ['2024-06-01', '50.00']]
+        tx_rows = [['Date', 'ISIN'], ['2024-01-15', 'LU0852473015']]
+        _write_csv(tmp_path / '2024_dividendes.csv', div_rows)
+        _write_csv(tmp_path / '2024_transactions.csv', tx_rows)
+
+        workbook = _build_workbook(tmp_path)
+
+        assert _sheet_rows(workbook['dividendes']) == div_rows
+        assert _sheet_rows(workbook['transactions']) == tx_rows
+
+    def test_row_count_matches_csv(self, tmp_path: Path) -> None:
+        rows = [['H1', 'H2']] + [[f'r{i}a', f'r{i}b'] for i in range(10)]
+        _write_csv(tmp_path / '2024_summary.csv', rows)
+
+        sheet = _build_workbook(tmp_path)['summary']
+
+        assert len(_sheet_rows(sheet)) == len(rows)
+
+    def test_column_count_matches_csv(self, tmp_path: Path) -> None:
+        rows = [['A', 'B', 'C', 'D', 'E'], ['1', '2', '3', '4', '5']]
+        _write_csv(tmp_path / '2024_fx_log.csv', rows)
+
+        sheet = _build_workbook(tmp_path)['fx_log']
+
+        for sheet_row, csv_row in zip(_sheet_rows(sheet), rows):
+            assert len(sheet_row) == len(csv_row)
+
+    def test_accented_characters_preserved(self, tmp_path: Path) -> None:
+        rows = [['Titre', 'Taux BCE', 'Montant arrondi'], ['fonds d\'actions', '1.0000', '1 234 €']]
+        _write_csv(tmp_path / '2024_dividendes.csv', rows)
+
+        sheet = _build_workbook(tmp_path)['dividendes']
+
+        assert _sheet_rows(sheet) == rows
+
+    def test_header_row_is_first_sheet_row(self, tmp_path: Path) -> None:
+        header = ['Date cession', 'ISIN', 'Plus/moins-value EUR (PMP)']
+        rows = [header, ['2024-03-10', 'GB00BJYDH287', '+500.00']]
+        _write_csv(tmp_path / '2024_gains_2074.csv', rows)
+
+        sheet = _build_workbook(tmp_path)['gains_2074']
+
+        assert _sheet_rows(sheet)[0] == header
+
+    # ------------------------------------------------------------------
+    # _convert_broker
+    # ------------------------------------------------------------------
+
+    def test_convert_broker_creates_xlsx_at_expected_path(self, tmp_path: Path) -> None:
+        year_dir = tmp_path / '2024'
+        broker_dir = year_dir / 'yuh'
+        broker_dir.mkdir(parents=True)
+        excel_dir = year_dir / 'excel'
+        excel_dir.mkdir()
+        _write_csv(broker_dir / '2024_transactions.csv', [['Date'], ['2024-01-01']])
+
+        _convert_broker('yuh', 2024, year_dir, excel_dir)
+
+        assert (excel_dir / 'yuh_2024_ifu.xlsx').exists()
+
+    def test_convert_broker_returns_true_on_success(self, tmp_path: Path) -> None:
+        year_dir = tmp_path / '2024'
+        broker_dir = year_dir / 'yuh'
+        broker_dir.mkdir(parents=True)
+        excel_dir = year_dir / 'excel'
+        excel_dir.mkdir()
+        _write_csv(broker_dir / '2024_transactions.csv', [['Date'], ['2024-01-01']])
+
+        result = _convert_broker('yuh', 2024, year_dir, excel_dir)
+
+        assert result is True
+
+    def test_convert_broker_returns_false_when_broker_dir_missing(self, tmp_path: Path) -> None:
+        year_dir = tmp_path / '2024'
+        year_dir.mkdir()
+        excel_dir = year_dir / 'excel'
+        excel_dir.mkdir()
+
+        result = _convert_broker('yuh', 2024, year_dir, excel_dir)
+
+        assert result is False
+
+    def test_convert_broker_returns_false_when_no_csvs_in_dir(self, tmp_path: Path) -> None:
+        year_dir = tmp_path / '2024'
+        broker_dir = year_dir / 'yuh'
+        broker_dir.mkdir(parents=True)
+        excel_dir = year_dir / 'excel'
+        excel_dir.mkdir()
+
+        result = _convert_broker('yuh', 2024, year_dir, excel_dir)
+
+        assert result is False
+
+    def test_convert_broker_excel_content_matches_source_csv(self, tmp_path: Path) -> None:
+        year_dir = tmp_path / '2024'
+        broker_dir = year_dir / 'yuh'
+        broker_dir.mkdir(parents=True)
+        excel_dir = year_dir / 'excel'
+        excel_dir.mkdir()
+        rows = [['Ticker', 'ISIN', 'Montant EUR'], ['MSFT', 'US5949181045', '999.99']]
+        _write_csv(broker_dir / '2024_transactions.csv', rows)
+
+        _convert_broker('yuh', 2024, year_dir, excel_dir)
+
+        workbook = openpyxl.load_workbook(excel_dir / 'yuh_2024_ifu.xlsx')
+        assert _sheet_rows(workbook['transactions']) == rows


### PR DESCRIPTION
## Summary

- Adds `src/csv_to_excel.py` as a standalone post-processing script: reads broker CSV outputs from `ifu-new/<year>/yuh/` and `ifu-new/<year>/wise/` and writes one `.xlsx` workbook per broker into `ifu-new/<year>/excel/`
- Each CSV becomes one sheet named after the file (year prefix stripped, e.g. `2024_gains_2074.csv` → sheet `gains_2074`)
- Missing broker folders are silently skipped — no error if only one broker was run
- Adds `openpyxl` to `requirements.txt`
- Documents the new script in `README.md`, `CLAUDE.md`, and `tasks/`

Closes #20

## Test plan

- [x] 19 pytest tests in `tests/test_csv_to_excel.py` — all passing
- [x] Covers: sheet naming, year-prefix stripping, 31-char truncation, content fidelity per sheet, row/column counts, accented characters, `_convert_broker` success/failure return values, end-to-end file creation and content via `load_workbook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)