### PR TITLE
refactor: rename --folder to --transactions-folder with -tf shorthand

### DIFF
--- a/FAQ-TECHNICAL.md
+++ b/FAQ-TECHNICAL.md
@@ -41,12 +41,12 @@ The README is for **users**: it covers what the tool does, which brokers are sup
 | `scripts/generate_ifu_yuh.sh`  | `src/yuh_csv_ifu.py`  | `bash scripts/generate_ifu_yuh.sh <year> [options]`  |
 | `scripts/generate_ifu_wise.sh` | `src/wise_csv_ifu.py` | `bash scripts/generate_ifu_wise.sh <year> [options]` |
 
-Both wrappers pass all arguments through to the underlying Python script (`"$@"`), so every optional flag — `--folder`, `--cache`, `-s`, `-f`, `-ff` — works exactly as documented for the Python scripts.
+Both wrappers pass all arguments through to the underlying Python script (`"$@"`), so every optional flag — `--transactions-folder`, `--cache`, `-s`, `-f`, `-ff` — works exactly as documented for the Python scripts.
 
 ```bash
 # Examples
 bash scripts/generate_ifu_yuh.sh 2024
-bash scripts/generate_ifu_wise.sh 2024 --folder transactions -s
+bash scripts/generate_ifu_wise.sh 2024 --transactions-folder transactions -s
 ```
 
 ---
@@ -67,7 +67,7 @@ The script resolves this via `TICKER_NAME_KEYWORDS` in `ticker_isin.py`: a dict 
 
 ## What filename format does `yuh_csv_ifu.py` expect for input CSV files?
 
-Files must be named `yuh_ACTIVITIES_REPORT-<year>.CSV` (or `.csv`) and placed inside the folder specified by `--folder` (default: `transactions/`). The `yuh_` prefix distinguishes Yuh exports from Wise files when both brokers' exports share the same folder.
+Files must be named `yuh_ACTIVITIES_REPORT-<year>.CSV` (or `.csv`) and placed inside the folder specified by `--transactions-folder` (default: `transactions/`). The `yuh_` prefix distinguishes Yuh exports from Wise files when both brokers' exports share the same folder.
 
 Example: `transactions/yuh_ACTIVITIES_REPORT-2024.CSV`
 
@@ -79,9 +79,9 @@ It was renamed to `generate_ifu_yuh.sh` to match the broker-specific naming conv
 
 ---
 
-## Why was `-f` removed as the shorthand for `--folder`?
+## Why was `-f` removed as the shorthand for `--transactions-folder`?
 
-The `-f` flag was reassigned to mean "formal penalty scenario" (40 % surcharge) when the `-s`/`-f`/`-ff` penalty shortcuts were introduced. Use the long form `--folder` instead. The default (`transactions/`) is correct for most setups, so this only affects users who were explicitly passing `-f <path>` on the command line.
+The `-f` flag was reassigned to mean "formal penalty scenario" (40 % surcharge) when the `-s`/`-f`/`-ff` penalty shortcuts were introduced. Use `--transactions-folder` (shorthand `-tf`) instead. The default (`transactions/`) is correct for most setups, so this only affects users who were explicitly passing `-f <path>` on the command line.
 
 ---
 
@@ -198,7 +198,7 @@ Python 3.7+ is sufficient to run all scripts.
 
 ## How do I use `fees_by_activity.py` to audit my Yuh broker fees?
 
-Run `python fees_by_activity.py <year>` (e.g., `python fees_by_activity.py 2023`). It reads `transactions/ACTIVITIES_REPORT-<year>.CSV`, sums the `FEES/COMMISSION` column grouped by `ACTIVITY TYPE`, and prints a table with a grand total. Use `--folder` to point to a different directory.
+Run `python fees_by_activity.py <year>` (e.g., `python fees_by_activity.py 2023`). It reads `transactions/ACTIVITIES_REPORT-<year>.CSV`, sums the `FEES/COMMISSION` column grouped by `ACTIVITY TYPE`, and prints a table with a grand total. Use `--transactions-folder` to point to a different directory.
 
 ```
 ACTIVITY TYPE                    FEES/COMMISSION

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Dependencies:
 ## Usage — Yuh / Swissquote
 
 ```bash
-bash scripts/generate_ifu_yuh.sh <year> [--folder <dir>] [--cache fx_cache.json]
+bash scripts/generate_ifu_yuh.sh <year> [--transactions-folder <dir>] [--cache fx_cache.json]
 ```
 
 Or directly:
 
 ```bash
-python src/yuh_csv_ifu.py 2024 [--folder transactions] [--cache fx_cache.json]
+python src/yuh_csv_ifu.py 2024 [--transactions-folder transactions] [--cache fx_cache.json]
 ```
 
 **With dispositions de Ruyter (frontaliers LAMal — PFU 20,3 %):**
@@ -77,13 +77,13 @@ python src/yuh_csv_ifu.py 2024 -ff   # fraud (80 %)
 ## Usage — Wise Assets
 
 ```bash
-bash scripts/generate_ifu_wise.sh <year> [--folder <dir>] [--cache fx_cache.json]
+bash scripts/generate_ifu_wise.sh <year> [--transactions-folder <dir>] [--cache fx_cache.json]
 ```
 
 Or directly:
 
 ```bash
-python src/wise_csv_ifu.py 2024 [--folder transactions] [--cache fx_cache.json]
+python src/wise_csv_ifu.py 2024 [--transactions-folder transactions] [--cache fx_cache.json]
 ```
 
 Same `--de-ruyter-periods` and penalty flags (`-s`, `-f`, `-ff`) apply.

--- a/scripts/generate_ifu_wise.sh
+++ b/scripts/generate_ifu_wise.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
-    echo "Usage: bash scripts/generate_ifu_wise.sh <année> [--folder <dossier>] [--cache <fichier_fx>] [-s|-f|-ff]" >&2
+    echo "Usage: bash scripts/generate_ifu_wise.sh <année> [--transactions-folder <dossier>] [--cache <fichier_fx>] [-s|-f|-ff]" >&2
     echo "  ex:  bash scripts/generate_ifu_wise.sh 2024" >&2
-    echo "  ex:  bash scripts/generate_ifu_wise.sh 2024 --folder transactions -s" >&2
+    echo "  ex:  bash scripts/generate_ifu_wise.sh 2024 --transactions-folder transactions -s" >&2
     exit 1
 fi
 

--- a/scripts/generate_ifu_yuh.sh
+++ b/scripts/generate_ifu_yuh.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
-    echo "Usage: bash scripts/generate_ifu_yuh.sh <année> [--folder <dossier>] [--cache <fichier_fx>] [-s|-f|-ff]" >&2
+    echo "Usage: bash scripts/generate_ifu_yuh.sh <année> [--transactions-folder <dossier>] [--cache <fichier_fx>] [-s|-f|-ff]" >&2
     echo "  ex:  bash scripts/generate_ifu_yuh.sh 2024" >&2
     exit 1
 fi

--- a/src/fees_by_activity.py
+++ b/src/fees_by_activity.py
@@ -4,7 +4,7 @@ fees_by_activity.py — Groupe les frais (FEES/COMMISSION) par ACTIVITY TYPE
 à partir des exports CSV Yuh (ACTIVITIES_REPORT-*.CSV).
 
 Usage:
-    python fees_by_activity.py <year> [--folder transactions]
+    python fees_by_activity.py <year> [--transactions-folder transactions]
 
 Exemple:
     python fees_by_activity.py 2023
@@ -41,17 +41,17 @@ def process_files(paths: list[Path]) -> dict[str, float]:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sum FEES/COMMISSION by ACTIVITY TYPE")
     parser.add_argument("year", help="Year suffix, e.g. 2023")
-    parser.add_argument("--folder", default="transactions", help="Folder containing the CSV files")
+    parser.add_argument("--transactions-folder", "-tf", default="transactions", help="Folder containing the CSV files")
     args = parser.parse_args()
 
-    path = Path(args.folder) / f"ACTIVITIES_REPORT-{args.year}.CSV"
+    path = Path(args.transactions_folder) / f"ACTIVITIES_REPORT-{args.year}.CSV"
     if not path.exists():
         print(f"File not found: {path}")
         return
     paths = [path]
 
     if not paths:
-        print(f"No CSV files found in '{args.folder}'.")
+        print(f"No CSV files found in '{args.transactions_folder}'.")
         return
 
     print(f"Processing {len(paths)} file(s):")

--- a/src/wise_csv_ifu.py
+++ b/src/wise_csv_ifu.py
@@ -4,7 +4,7 @@ wise_csv_ifu.py — Calcule l'équivalent d'un IFU à partir des exports CSV Wis
 pour la déclaration fiscale française (résident fiscal français, frontalier).
 
 Usage:
-    python3 src/wise_csv_ifu.py <année> [--folder <dossier>] [--cache <fichier_fx>]
+    python3 src/wise_csv_ifu.py <année> [--transactions-folder <dossier>] [--cache <fichier_fx>]
 
 Produit (ifu/wise/<année>/) :
     - <année>_transactions.csv  : opérations de l'année avec conversion EUR
@@ -14,7 +14,7 @@ Produit (ifu/wise/<année>/) :
     - <année>_summary.csv       : positions et PMP au 31/12 de l'année cible
     - <année>_fx_log.csv        : journal des taux BCE utilisés
 
-Input : fichiers `wise_assets_statement_*.csv` dans `--folder`.
+Input : fichiers `wise_assets_statement_*.csv` dans `--transactions-folder`.
 
 Colonnes CSV Wise Assets :
     Traded Asset ID Type | Traded Asset ID Value | Execution Date | Transaction Type |
@@ -313,7 +313,7 @@ def main():
         epilog=__doc__,
     )
     parser.add_argument('year', type=int, help='Année fiscale cible (ex. 2024)')
-    parser.add_argument('--folder', default='transactions',
+    parser.add_argument('--transactions-folder', '-tf', default='transactions',
                         help="Dossier contenant les CSV Wise (défaut: 'transactions')")
     parser.add_argument('--cache', default='fx_cache.json',
                         help="Fichier cache taux BCE (défaut: fx_cache.json)")
@@ -352,7 +352,7 @@ def main():
     de_ruyter = load_de_ruyter_arg(args.de_ruyter_periods)
 
     target_year = args.year
-    folder = Path(args.folder)
+    folder = Path(args.transactions_folder)
     out_dir = Path(args.out) / str(target_year) / 'wise'
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/yuh_csv_ifu.py
+++ b/src/yuh_csv_ifu.py
@@ -4,7 +4,7 @@ yuh_csv_ifu.py — Calcule l'équivalent d'un IFU à partir des exports CSV Yuh
 pour la déclaration fiscale française (résident fiscal français).
 
 Usage:
-    python3 yuh_csv_ifu.py <année> [--folder <dossier>] [--cache <fichier_fx>]
+    python3 yuh_csv_ifu.py <année> [--transactions-folder <dossier>] [--cache <fichier_fx>]
                            [-cldp [--penalty-scenario {spontaneous,formal,fraud}]
                                   [--declaration-deadline YYYY-MM-DD]]
 
@@ -330,7 +330,7 @@ def main():
     )
     parser.add_argument('year', type=int,
                         help='Année fiscale cible (ex. 2024)')
-    parser.add_argument('--folder', default='transactions',
+    parser.add_argument('--transactions-folder', '-tf', default='transactions',
                         help="Dossier contenant les CSV Yuh (défaut: 'transactions')")
     parser.add_argument('--cache', default='fx_cache.json',
                         help="Fichier cache des taux BCE (défaut: fx_cache.json)")
@@ -380,7 +380,7 @@ def main():
     de_ruyter = load_de_ruyter_arg(args.de_ruyter_periods)
 
     target_year = args.year
-    folder = Path(args.folder)
+    folder = Path(args.transactions_folder)
     out_dir = Path(args.out) / str(target_year) / 'yuh'
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def _run(script: str, arguments: list[str]) -> subprocess.CompletedProcess:
 
 
 def _generate_year(year: int) -> None:
-    shared = ["--folder", str(TRANSACTIONS), "--cache", "fx_cache.json", "--out", str(OUTPUT_ROOT)]
+    shared = ["--transactions-folder", str(TRANSACTIONS), "--cache", "fx_cache.json", "--out", str(OUTPUT_ROOT)]
     if _has_yuh_csv(year):
         _run("yuh_csv_ifu.py", [str(year)] + shared)
     if _has_wise_csv(year):


### PR DESCRIPTION
## Summary

- Renamed the `--folder` CLI argument to `--transactions-folder` (shorthand `-tf`) across all Python scripts (`yuh_csv_ifu.py`, `wise_csv_ifu.py`, `fees_by_activity.py`) to make the argument self-documenting
- Updated `args.folder` → `args.transactions_folder` throughout (argparse auto-converts hyphens to underscores)
- Updated `tests/conftest.py`, shell wrappers, `README.md`, and `FAQ-TECHNICAL.md` to match

Closes #25

## Test plan

- [x] 67 tests pass (`pytest tests/ -v`), 1 pre-existing skip unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)